### PR TITLE
Added default removed AuthnContext restrictions to support X509

### DIFF
--- a/lib/php-saml/settings.php
+++ b/lib/php-saml/settings.php
@@ -67,4 +67,9 @@ $phpsamlsettings = array (
         'x509cert' => (isset($config['saml_idp_certificate']) ? $config['saml_idp_certificate'] : ''),
         
     ),
+
+    // Security settings
+    'security' => array (
+        'requestedAuthnContext' => false
+    )
 );


### PR DESCRIPTION
Added default setting to settings.php to bypass rendering RequestedAuthnContext in SAMLRequest as advanced_settings.php is not loaded by the plugin.
This fixes auth with X509 and may probably fix OneTimePasscode.