### PR TITLE
Update phpsaml.class.php

### DIFF
--- a/inc/phpsaml.class.php
+++ b/inc/phpsaml.class.php
@@ -409,25 +409,27 @@ class PluginPhpsamlPhpsaml
 	}
 	
 	static public function getAuthn($value){
-		if (!isset($value) || $value == ''){
+		if(preg_match('/^none,.+/i', $value)){
+			$array = explode(',', $value);
+			$output = array();
+			// TODO: Current configuration input field allows multiple Items, logic below will select the first found then break. 
+			// Because of this the end result might not be what the user expects based on the config screen.
+			foreach ($array as $item){
+				switch($item){
+					case 'PasswordProtectedTransport':
+						$output[] = 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport';
+						break;
+					case 'Password':
+						$output[] = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password';
+						break;
+					case 'X509':
+						$output[] = 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509';
+						break;
+				}
+			}
+			return $output;
+		}else{
 			return false;
 		}
-		
-		$array = explode(',', $value);
-		$output = array();
-		foreach ($array as $item){
-			switch($item){
-				case 'PasswordProtectedTransport':
-					$output[] = 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport';
-					break;
-				case 'Password':
-					$output[] = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password';
-					break;
-				case 'X509':
-					$output[] = 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509';
-					break;
-			}
-		}
-		return $output;
 	}
 }

--- a/setup.php
+++ b/setup.php
@@ -215,9 +215,13 @@ function plugin_post_init_phpsaml(){
 				Html::nullFooter();
 				exit();
 			} else {
+				// Fix for invalid redirect errors when port number is included in HTTP_HOST.
+				// Maybe replace it with GLPI config: URL of the application? 
+				list($realhost,)=explode(':',$_SERVER['HTTP_HOST']);
+				
 				// lets check for the redirect parameter, if it doesn't exist lets redirect the visitor back to the original page
 				// Fixed in 1.2.0 - Resolved Undefinded index: HTTP_HOST
-				$returnTo = (isset($_GET['redirect']) ? $_GET['redirect'] : (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://" . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
+				$returnTo = (isset($_GET['redirect']) ? $_GET['redirect'] : (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://" . $realhost . $_SERVER['REQUEST_URI']);
 				$phpsaml::ssoRequest($returnTo);
 			}
 		}


### PR DESCRIPTION
Fix for GetAuthN. 

Used following to locally test the changed function.

function eval_Authn($value){
        if(preg_match('/^none,.+/i', $value)){
                return true;
        }else{
                return false;
        }
}

$tests = array('none'      => false,
               'none,x509' => true,
               'none,Password' => true,
               'none,PasswordProtectedTransport' => true,
               'none,' => false);

foreach($tests as $v => $r){
        if(eval_Authn($v) == $r){
                print "$v returned expected value<br>";
        }else{
                print "$v DID NOT return expected value!<br>";
        }
}

-----

Fixed issue in which port number was included with HTTP_HOST. GLPI redirect does not allow port numbers in provided redirects. 