### PR TITLE
fix glpi_plugin_phpsaml_configs initial insertion and GLPI_ROOT definition

### DIFF
--- a/front/acs.php
+++ b/front/acs.php
@@ -1,18 +1,19 @@
 <?php
-if (!defined('GLPI_ROOT')) {
-    define('GLPI_ROOT', '../../..');
+if (defined('GLPI_ROOT')) {
+    $glpi_root = GLPI_ROOT;
+} else {
+    $glpi_root = '../../..';
 }
-
 
 
 $post = $_POST;
 unset($_POST);
 
-include (GLPI_ROOT.'/inc/includes.php');
+include ($glpi_root.'/inc/includes.php');
 
-require_once GLPI_ROOT.'/plugins/phpsaml/lib/xmlseclibs/xmlseclibs.php';
-$libDir = GLPI_ROOT.'/plugins/phpsaml/lib/php-saml/src/Saml2/';
-		
+require_once $glpi_root.'/plugins/phpsaml/lib/xmlseclibs/xmlseclibs.php';
+$libDir = $glpi_root.'/plugins/phpsaml/lib/php-saml/src/Saml2/';
+
 $folderInfo = scandir($libDir);
 
 foreach ($folderInfo as $element) {
@@ -26,7 +27,7 @@ use OneLogin\Saml2\Response;
 
 $error = null;
 $phpsaml = new PluginPhpsamlPhpsaml();
-		
+
 try {
     if (isset($post['SAMLResponse'])) {
 		$settings = $phpsaml::$phpsamlsettings;

--- a/hook.php
+++ b/hook.php
@@ -71,14 +71,14 @@ function plugin_phpsaml_install() {
             PRIMARY KEY  (`id`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
 		$DB->query($query) or die("error creating glpi_plugin_phpsaml_configs ". $DB->error());
-		
+
 		$query = "INSERT INTO `glpi_plugin_phpsaml_configs`
             (`id`,`version`, `enforced`, `strict`, `debug`, `jit`, `saml_sp_certificate`, `saml_sp_certificate_key`, `saml_sp_nameid_format`, `saml_idp_entity_id`, `saml_idp_single_sign_on_service`, `saml_idp_single_logout_service`, `saml_idp_certificate`, `requested_authn_context`, `requested_authn_context_comparison`, `saml_security_nameidencrypted`, `saml_security_authnrequestssigned`, `saml_security_logoutrequestsigned`, `saml_security_logoutresponsesigned`)
             VALUES
-            ('1', '". PLUGIN_PHPSAML_VERSION ."', '0', '1','0', '', '', '', '', '', '', '', '', '', '','0','0','0','0')";
+            ('1', '". PLUGIN_PHPSAML_VERSION ."', '0', '1','0', '0', '', '', '', '', '', '', '', '', '','0','0','0','0')";
 		$DB->query($query) or die("error populate glpi_plugin_phpsaml_configs ". $DB->error());
 	}
-	
+
 	if ($DB->tableExists('glpi_plugin_phpsaml_configs')) {
 		include_once( PLUGIN_PHPSAML_DIR . "/install/update.class.php" );
 		$update = new PluginPhpsamlUpdate();


### PR DESCRIPTION
The install process was misbehaving and attempts to initialize the `jit` column in the `glpi_plugin_phpsaml_configs` table entry with an empty string rather an integer.

This results in inability to update the plugin configuration and shows empty values every time an **update** is executed.

my setup: Glpi 10.0.3, phpsaml 1.2.1

fixes #101 #98 #86 (at least the main issue mention in either one of them)