### PR TITLE
Fix undefined global variable $_POST in GLPI 10.0.12

### DIFF
--- a/front/acs.php
+++ b/front/acs.php
@@ -8,6 +8,7 @@ if (defined('GLPI_ROOT')) {
 
 $post = $_POST;
 unset($_POST);
+$_POST = array();
 
 include ($glpi_root.'/inc/includes.php');
 


### PR DESCRIPTION
Fixes #164

Since 10.0.12, GLPI errors when logging in through SAML:
Undefined global variable $_POST in GLPI_ROOT/inc/includes.php on line 102

This issue can be solved by initializing the global variable $_POST as an empty array.